### PR TITLE
rabbitmqmanager: don't print additional new line

### DIFF
--- a/src/main/java/me/drepic/proton/common/RabbitMQManager.java
+++ b/src/main/java/me/drepic/proton/common/RabbitMQManager.java
@@ -68,7 +68,7 @@ public class RabbitMQManager extends ProtonManager {
         queueName = channel.queueDeclare().getQueue();
         channel.basicConsume(queueName, true, this::deliverCallback, consumerTag -> {});
 
-        getLogger().info(String.format("Connected as '%s' with id:%s\n", this.name, this.id.toString()));
+        getLogger().info(String.format("Connected as '%s' with id:%s", this.name, this.id.toString()));
     }
 
     protected void deliverCallback(String consumerTag, Delivery delivery) {


### PR DESCRIPTION
Signed-off-by: Alexander Trost <galexrt@googlemail.com>

***

Right now an empty line is printed after the log line:

```
[15:56:26 INFO]: [Proton] Enabling Proton v1.3.1*
[15:56:26 INFO]: [Proton] Connected as 'lobby-0' with id:__ID__

[15:56:26 INFO]: [Example] Enabling Example v0.0.1
```

I know it is just an empty line but I thought I should fix this :smile: